### PR TITLE
backport mayhem-fms-2025 changes that are generic into mayhem-fms-generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ _testmain.go
 .DS_Store
 static/logs
 static/img/avatars
+
+# Linemate
+.linemate/

--- a/game/score.go
+++ b/game/score.go
@@ -66,7 +66,7 @@ func (score *Score) Summarize(opponentScore *Score) *ScoreSummary {
 	summary.Score = summary.MatchPoints + summary.FoulPoints
 
 	// Calculate bonus ranking points.
-	// Leave Bonus RP
+	// Auton Bonus RP
 	allRobotsLeft := true
 	for i, left := range score.Mayhem.LeaveStatuses {
 		if !left && !score.RobotsBypassed[i] {
@@ -75,15 +75,15 @@ func (score *Score) Summarize(opponentScore *Score) *ScoreSummary {
 		}
 	}
 	if allRobotsLeft {
-		summary.LeaveBonusRankingPoint = true
+		summary.AutonRankingPoint = true
 	}
 
-	// Gamepiece 1 Bonus RP
+	// Scoring Bonus RP
 	if summary.NumGamepiece1 >= Gamepiece1RPThreshold {
-		summary.Gamepiece1BonusRankingPoint = true
+		summary.ScoringRankingPoint = true
 	}
 
-	// Park Bonus RP
+	// Endgame Bonus RP
 	allRobotsParked := true
 	for i, parked := range score.Mayhem.ParkStatuses {
 		if !parked && !score.RobotsBypassed[i] {
@@ -92,17 +92,17 @@ func (score *Score) Summarize(opponentScore *Score) *ScoreSummary {
 		}
 	}
 	if allRobotsParked {
-		summary.ParkBonusRankingPoint = true
+		summary.EndgameRankingPoint = true
 	}
 
 	// Add up the bonus ranking points.
-	if summary.LeaveBonusRankingPoint {
+	if summary.AutonRankingPoint {
 		summary.BonusRankingPoints++
 	}
-	if summary.Gamepiece1BonusRankingPoint {
+	if summary.ScoringRankingPoint {
 		summary.BonusRankingPoints++
 	}
-	if summary.ParkBonusRankingPoint {
+	if summary.EndgameRankingPoint {
 		summary.BonusRankingPoints++
 	}
 

--- a/game/score_summary.go
+++ b/game/score_summary.go
@@ -16,9 +16,9 @@ type ScoreSummary struct {
 	MatchPoints                 int
 	FoulPoints                  int
 	Score                       int
-	LeaveBonusRankingPoint      bool
-	Gamepiece1BonusRankingPoint bool
-	ParkBonusRankingPoint       bool
+	AutonRankingPoint           bool
+	ScoringRankingPoint         bool
+	EndgameRankingPoint         bool
 	BonusRankingPoints          int
 	NumOpponentMajorFouls       int
 }

--- a/game/score_test.go
+++ b/game/score_test.go
@@ -24,9 +24,9 @@ func TestScoreSummary(t *testing.T) {
 	assert.Equal(t, 63, redSummary.MatchPoints)
 	assert.Equal(t, 0, redSummary.FoulPoints)
 	assert.Equal(t, 63, redSummary.Score)
-	assert.Equal(t, true, redSummary.LeaveBonusRankingPoint)
-	assert.Equal(t, true, redSummary.Gamepiece1BonusRankingPoint)
-	assert.Equal(t, true, redSummary.ParkBonusRankingPoint)
+	assert.Equal(t, true, redSummary.AutonRankingPoint)
+	assert.Equal(t, true, redSummary.ScoringRankingPoint)
+	assert.Equal(t, true, redSummary.EndgameRankingPoint)
 	assert.Equal(t, 3, redSummary.BonusRankingPoints)
 	assert.Equal(t, 0, redSummary.NumOpponentMajorFouls)
 
@@ -41,9 +41,9 @@ func TestScoreSummary(t *testing.T) {
 	assert.Equal(t, 62, blueSummary.MatchPoints)
 	assert.Equal(t, 34, blueSummary.FoulPoints)
 	assert.Equal(t, 96, blueSummary.Score)
-	assert.Equal(t, false, blueSummary.LeaveBonusRankingPoint)
-	assert.Equal(t, true, blueSummary.Gamepiece1BonusRankingPoint)
-	assert.Equal(t, false, blueSummary.ParkBonusRankingPoint)
+	assert.Equal(t, false, blueSummary.AutonRankingPoint)
+	assert.Equal(t, true, blueSummary.ScoringRankingPoint)
+	assert.Equal(t, false, blueSummary.EndgameRankingPoint)
 	assert.Equal(t, 1, blueSummary.BonusRankingPoints)
 	assert.Equal(t, 5, blueSummary.NumOpponentMajorFouls)
 }
@@ -75,7 +75,7 @@ func TestScoreEquals(t *testing.T) {
 	assert.False(t, score1.Equals(score2))
 }
 
-func TestLeaveBonusRankingPoint(t *testing.T) {
+func TestAutonRankingPoint(t *testing.T) {
 	score := Score{
 		RobotsBypassed: [3]bool{false, false, false},
 		Mayhem: Mayhem{
@@ -83,30 +83,30 @@ func TestLeaveBonusRankingPoint(t *testing.T) {
 		},
 	}
 	summary := score.Summarize(&Score{})
-	assert.True(t, summary.LeaveBonusRankingPoint)
+	assert.True(t, summary.AutonRankingPoint)
 
 	score.Mayhem.LeaveStatuses[1] = false
 	summary = score.Summarize(&Score{})
-	assert.False(t, summary.LeaveBonusRankingPoint)
+	assert.False(t, summary.AutonRankingPoint)
 
 	score.Mayhem.LeaveStatuses[1] = true
 	score.RobotsBypassed[1] = true
 	score.Mayhem.LeaveStatuses[1] = false
 	summary = score.Summarize(&Score{})
-	assert.True(t, summary.LeaveBonusRankingPoint)
+	assert.True(t, summary.AutonRankingPoint)
 }
 
-func TestGamepiece1BonusRankingPoint(t *testing.T) {
+func TestScoringRankingPoint(t *testing.T) {
 	score := Score{Mayhem: Mayhem{AutoGamepiece1Level1Count: 4, TeleopGamepiece1Level2Count: 4}}
 	summary := score.Summarize(&Score{})
-	assert.True(t, summary.Gamepiece1BonusRankingPoint)
+	assert.True(t, summary.ScoringRankingPoint)
 
 	score.Mayhem.TeleopGamepiece1Level2Count = 3
 	summary = score.Summarize(&Score{})
-	assert.False(t, summary.Gamepiece1BonusRankingPoint)
+	assert.False(t, summary.ScoringRankingPoint)
 }
 
-func TestParkBonusRankingPoint(t *testing.T) {
+func TestEndgameRankingPoint(t *testing.T) {
 	score := Score{
 		RobotsBypassed: [3]bool{false, false, false},
 		Mayhem: Mayhem{
@@ -114,15 +114,15 @@ func TestParkBonusRankingPoint(t *testing.T) {
 		},
 	}
 	summary := score.Summarize(&Score{})
-	assert.True(t, summary.ParkBonusRankingPoint)
+	assert.True(t, summary.EndgameRankingPoint)
 
 	score.Mayhem.ParkStatuses[1] = false
 	summary = score.Summarize(&Score{})
-	assert.False(t, summary.ParkBonusRankingPoint)
+	assert.False(t, summary.EndgameRankingPoint)
 
 	score.Mayhem.ParkStatuses[1] = true
 	score.RobotsBypassed[1] = true
 	score.Mayhem.ParkStatuses[1] = false
 	summary = score.Summarize(&Score{})
-	assert.True(t, summary.ParkBonusRankingPoint)
+	assert.True(t, summary.EndgameRankingPoint)
 }

--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -22,6 +22,7 @@ type EventSettings struct {
 	SelectionRound2Order        string
 	SelectionRound3Order        string
 	SelectionShowUnpickedTeams  bool
+	GreenScreen                 bool
 	TwoVsTwoMode                bool
 	TbaDownloadEnabled          bool
 	TbaPublishingEnabled        bool

--- a/static/css/audience_display.css
+++ b/static/css/audience_display.css
@@ -158,6 +158,21 @@ html {
   line-height: 27px;
   color: #fff;
 }
+.score-value {
+  width: 70px;
+  text-align: center;
+  font-family: "FuturaLTBold";
+  font-size: 27px;
+  line-height: 27px;
+  color: #fff;
+}
+.reversible-left .score-field {
+  padding-left: 10px;
+}
+.reversible-right .score-field {
+  flex-direction: row-reverse;
+  padding-right: 10px;
+}
 #matchCircle {
   position: absolute;
   top: -25px;
@@ -347,24 +362,40 @@ html {
   color: #222;
   font-family: "FuturaLT";
   font-size: 24px;
+  line-height: 1.8;
 }
 #leftFinalBreakdown {
   width: 60px;
   padding-right: 10px;
-  align-items: flex-end;
+  text-align: right;
 }
 #rightFinalBreakdown {
   width: 60px;
   padding-left: 10px;
-  align-items: flex-start;
+  text-align: left;
 }
 #centerFinalBreakdown {
   width: 280px;
-  align-items: center;
   text-align: center;
   border-left: 2px solid #333;
   border-right: 2px solid #333;
 }
+#leftFinalBreakdown > div:not(.playoff-hidden-field),
+#leftFinalBreakdown > .playoff-hidden-field > div,
+#rightFinalBreakdown > div:not(.playoff-hidden-field),
+#rightFinalBreakdown > .playoff-hidden-field > div,
+#centerFinalBreakdown > div:not(.playoff-hidden-field),
+#centerFinalBreakdown > .playoff-hidden-field > div {
+  height: 38px;
+  display: flex;
+  align-items: center;
+}
+#leftFinalBreakdown > div:not(.playoff-hidden-field),
+#leftFinalBreakdown > .playoff-hidden-field > div { justify-content: flex-end; }
+#rightFinalBreakdown > div:not(.playoff-hidden-field),
+#rightFinalBreakdown > .playoff-hidden-field > div { justify-content: flex-start; }
+#centerFinalBreakdown > div:not(.playoff-hidden-field),
+#centerFinalBreakdown > .playoff-hidden-field > div { justify-content: center; }
 .final-breakdown-teams {
   flex-grow: 1;
   display: flex;

--- a/static/js/audience_display.js
+++ b/static/js/audience_display.js
@@ -177,12 +177,12 @@ const handleScorePosted = function (data) {
   $(`#${redSide}FinalGamepiece2Points`).text(data.RedScoreSummary.Gamepiece2Points);
   $(`#${redSide}FinalParkPoints`).text(data.RedScoreSummary.ParkPoints);
   $(`#${redSide}FinalFoulPoints`).text(data.RedScoreSummary.FoulPoints);
-  $(`#${redSide}FinalLeaveRankingPoint`).html(data.RedScoreSummary.LeaveBonusRankingPoint ? "&#x2714;" : "&#x2718;");
-  $(`#${redSide}FinalLeaveRankingPoint`).attr("data-checked", data.RedScoreSummary.LeaveBonusRankingPoint);
-  $(`#${redSide}FinalGamepiece1RankingPoint`).html(data.RedScoreSummary.Gamepiece1BonusRankingPoint ? "&#x2714;" : "&#x2718;");
-  $(`#${redSide}FinalGamepiece1RankingPoint`).attr("data-checked", data.RedScoreSummary.Gamepiece1BonusRankingPoint);
-  $(`#${redSide}FinalParkRankingPoint`).html(data.RedScoreSummary.ParkBonusRankingPoint ? "&#x2714;" : "&#x2718;");
-  $(`#${redSide}FinalParkRankingPoint`).attr("data-checked", data.RedScoreSummary.ParkBonusRankingPoint);
+  $(`#${redSide}FinalAutonRankingPoint`).html(data.RedScoreSummary.AutonRankingPoint ? "&#x2714;" : "&#x2718;");
+  $(`#${redSide}FinalAutonRankingPoint`).attr("data-checked", data.RedScoreSummary.AutonRankingPoint);
+  $(`#${redSide}FinalScoringRankingPoint`).html(data.RedScoreSummary.ScoringRankingPoint ? "&#x2714;" : "&#x2718;");
+  $(`#${redSide}FinalScoringRankingPoint`).attr("data-checked", data.RedScoreSummary.ScoringRankingPoint);
+  $(`#${redSide}FinalEndgameRankingPoint`).html(data.RedScoreSummary.EndgameRankingPoint ? "&#x2714;" : "&#x2718;");
+  $(`#${redSide}FinalEndgameRankingPoint`).attr("data-checked", data.RedScoreSummary.EndgameRankingPoint);
   $(`#${redSide}FinalRankingPoints`).html(data.RedRankingPoints);
 
   $(`#${blueSide}FinalScore`).text(data.BlueScoreSummary.Score);
@@ -200,12 +200,12 @@ const handleScorePosted = function (data) {
   $(`#${blueSide}FinalGamepiece2Points`).text(data.BlueScoreSummary.Gamepiece2Points);
   $(`#${blueSide}FinalParkPoints`).text(data.BlueScoreSummary.ParkPoints);
   $(`#${blueSide}FinalFoulPoints`).text(data.BlueScoreSummary.FoulPoints);
-  $(`#${blueSide}FinalLeaveRankingPoint`).html(data.BlueScoreSummary.LeaveBonusRankingPoint ? "&#x2714;" : "&#x2718;");
-  $(`#${blueSide}FinalLeaveRankingPoint`).attr("data-checked", data.BlueScoreSummary.LeaveBonusRankingPoint);
-  $(`#${blueSide}FinalGamepiece1RankingPoint`).html(data.BlueScoreSummary.Gamepiece1BonusRankingPoint ? "&#x2714;" : "&#x2718;");
-  $(`#${blueSide}FinalGamepiece1RankingPoint`).attr("data-checked", data.BlueScoreSummary.Gamepiece1BonusRankingPoint);
-  $(`#${blueSide}FinalParkRankingPoint`).html(data.BlueScoreSummary.ParkBonusRankingPoint ? "&#x2714;" : "&#x2718;");
-  $(`#${blueSide}FinalParkRankingPoint`).attr("data-checked", data.BlueScoreSummary.ParkBonusRankingPoint);
+  $(`#${blueSide}FinalAutonRankingPoint`).html(data.BlueScoreSummary.AutonRankingPoint ? "&#x2714;" : "&#x2718;");
+  $(`#${blueSide}FinalAutonRankingPoint`).attr("data-checked", data.BlueScoreSummary.AutonRankingPoint);
+  $(`#${blueSide}FinalScoringRankingPoint`).html(data.BlueScoreSummary.ScoringRankingPoint ? "&#x2714;" : "&#x2718;");
+  $(`#${blueSide}FinalScoringRankingPoint`).attr("data-checked", data.BlueScoreSummary.ScoringRankingPoint);
+  $(`#${blueSide}FinalEndgameRankingPoint`).html(data.BlueScoreSummary.EndgameRankingPoint ? "&#x2714;" : "&#x2718;");
+  $(`#${blueSide}FinalEndgameRankingPoint`).attr("data-checked", data.BlueScoreSummary.EndgameRankingPoint);
   $(`#${blueSide}FinalRankingPoints`).html(data.BlueRankingPoints);
 
   let matchName = data.Match.LongName;

--- a/static/js/match_play.js
+++ b/static/js/match_play.js
@@ -6,6 +6,7 @@
 var websocket;
 let scoreIsReady;
 let isReplay;
+let twoVsTwoMode;
 const lowBatteryThreshold = 8;
 
 // Sends a websocket message to load the specified match.
@@ -19,14 +20,14 @@ const showResult = function (matchId) {
 }
 
 // Sends a websocket message to load all teams into their respective alliance stations.
-const substituteTeams = function (team, position) {
+const substituteTeams = function () {
   const teams = {
     Red1: getTeamNumber("R1"),
     Red2: getTeamNumber("R2"),
-    Red3: getTeamNumber("R3"),
+    Red3: twoVsTwoMode ? 0 : getTeamNumber("R3"),
     Blue1: getTeamNumber("B1"),
     Blue2: getTeamNumber("B2"),
-    Blue3: getTeamNumber("B3"),
+    Blue3: twoVsTwoMode ? 0 : getTeamNumber("B3"),
   };
 
   websocket.send("substituteTeams", teams);
@@ -281,6 +282,7 @@ const handleArenaStatus = function (data) {
 // Handles a websocket message to update the teams for the current match.
 const handleMatchLoad = function (data) {
   isReplay = data.IsReplay;
+  twoVsTwoMode = data.TwoVsTwoMode;
 
   fetch("/match_play/match_load")
     .then(response => response.text())

--- a/templates/alliance_selection.html
+++ b/templates/alliance_selection.html
@@ -45,7 +45,9 @@ UI for controlling the alliance selection process.
             <th>Alliance #</th>
             <th>Captain</th>
             <th>Pick 1</th>
+            {{if not .TwoVsTwoMode}}
             <th>Pick 2</th>
+            {{end}}
             {{if (index .Alliances 0).TeamIds | len | eq 4}}
             <th>Pick 3</th>
             {{end}}

--- a/templates/announcer_display_score_posted.html
+++ b/templates/announcer_display_score_posted.html
@@ -51,16 +51,16 @@
 </div>
 {{if ne .matchType playoffMatch}}
 <div class="row justify-content-center">
-  <div class="col-sm-6">Leave Bonus RP</div>
-  <div class="col-sm-4">{{if .summary.LeaveBonusRankingPoint}}Yes{{else}}No{{end}}</div>
+  <div class="col-sm-6">Auton Bonus RP</div>
+  <div class="col-sm-4">{{if .summary.AutonRankingPoint}}Yes{{else}}No{{end}}</div>
 </div>
 <div class="row justify-content-center">
-  <div class="col-sm-6">Gamepiece 1 Bonus RP</div>
-  <div class="col-sm-4">{{if .summary.Gamepiece1BonusRankingPoint}}Yes{{else}}No{{end}}</div>
+  <div class="col-sm-6">Scoring Bonus RP</div>
+  <div class="col-sm-4">{{if .summary.ScoringRankingPoint}}Yes{{else}}No{{end}}</div>
 </div>
 <div class="row justify-content-center">
-  <div class="col-sm-6">Park Bonus RP</div>
-  <div class="col-sm-4">{{if .summary.ParkBonusRankingPoint}}Yes{{else}}No{{end}}</div>
+  <div class="col-sm-6">Endgame Bonus RP</div>
+  <div class="col-sm-4">{{if .summary.EndgameRankingPoint}}Yes{{else}}No{{end}}</div>
 </div>
 {{end}}
 <div class="row justify-content-center mt-3">

--- a/templates/audience_display.html
+++ b/templates/audience_display.html
@@ -142,9 +142,9 @@ Display shown on the audience screen overlayed over the video.
               <div id="leftFinalParkPoints"></div>
               <div id="leftFinalFoulPoints"></div>
               <div class="playoff-hidden-field">
-                <div id="leftFinalLeaveRankingPoint"></div>
-                <div id="leftFinalGamepiece1RankingPoint"></div>
-                <div id="leftFinalParkRankingPoint"></div>
+                <div id="leftFinalAutonRankingPoint"></div>
+                <div id="leftFinalScoringRankingPoint"></div>
+                <div id="leftFinalEndgameRankingPoint"></div>
                 <div id="leftFinalRankingPoints"></div>
               </div>
             </div>
@@ -168,9 +168,9 @@ Display shown on the audience screen overlayed over the video.
               <div id="rightFinalParkPoints"></div>
               <div id="rightFinalFoulPoints"></div>
               <div class="playoff-hidden-field">
-                <div id="rightFinalLeaveRankingPoint"></div>
-                <div id="rightFinalGamepiece1RankingPoint"></div>
-                <div id="rightFinalParkRankingPoint"></div>
+                <div id="rightFinalAutonRankingPoint"></div>
+                <div id="rightFinalScoringRankingPoint"></div>
+                <div id="rightFinalEndgameRankingPoint"></div>
                 <div id="rightFinalRankingPoints"></div>
               </div>
             </div>

--- a/templates/edit_match_result.html
+++ b/templates/edit_match_result.html
@@ -31,7 +31,7 @@ UI for manually editing the result for a match.
     <legend>Autonomous</legend>
     <h6 class="fw-bold mb-2">Bypassed</h6>
     <div class="row mb-3">
-      {{range $i := seq 3}}
+      {{range $i := seq .NumTeamsPerAlliance}}
       <div class="col-lg-2">
         <label class="control-label">Team {{"{{team"}}{{$i}}{{"}}"}}</label>
         <input type="checkbox" class="ms-3" name="{{"{{alliance}}"}}RobotsBypassed{{$i}}">
@@ -40,7 +40,7 @@ UI for manually editing the result for a match.
     </div>
     <h6 class="fw-bold mb-2">Leave</h6>
     <div class="row mb-3">
-      {{range $i := seq 3}}
+      {{range $i := seq .NumTeamsPerAlliance}}
       <div class="col-lg-2">
         <label class="control-label">Team {{"{{team"}}{{$i}}{{"}}"}}</label>
         <input type="checkbox" class="ms-3" name="{{"{{alliance}}"}}LeaveStatuses{{$i}}">
@@ -106,7 +106,7 @@ UI for manually editing the result for a match.
   <fieldset>
     <legend>Endgame</legend>
     <div class="mb-3">
-      {{range $i := seq 3}}
+      {{range $i := seq .NumTeamsPerAlliance}}
       <div class="row mb-2">
         <label class="col-lg-1 control-label">Team {{"{{team"}}{{$i}}{{"}}"}}</label>
         <div class="col-lg-1">
@@ -156,12 +156,14 @@ UI for manually editing the result for a match.
               Team {{"{{../team2}}"}}
             </label>
           </div>
+          {{if not .TwoVsTwoMode}}
           <div class="col-lg-2">
             <label>
               <input type="radio" name="{{"{{../alliance}}"}}Foul{{"{{@index}}"}}Team" value="{{"{{../team3}}"}}">
               Team {{"{{../team3}}"}}
             </label>
           </div>
+          {{end}}
         </div>
       </div>
     </div>
@@ -187,7 +189,7 @@ Add Foul
 </fieldset>
 <fieldset>
   <legend>Cards</legend>
-  {{range $i := seq 3}}
+  {{range $i := seq .NumTeamsPerAlliance}}
   <div class="row mb-3">
     <label class="col-lg-2 control-label">Team {{"{{team"}}{{$i}}{{"}}"}}</label>
     <div class="col-lg-8">

--- a/templates/match_logs.html
+++ b/templates/match_logs.html
@@ -49,9 +49,11 @@ UI for listing matches and their logs.
               <a href="/match_logs/{{$match.Id}}/R2/log" target="_blank"><b class="btn btn-danger btn-sm btn-logs">
                 {{index $match.RedTeams 1}}
               </b></a>
+              {{if not $.EventSettings.TwoVsTwoMode}}
               <a href="/match_logs/{{$match.Id}}/R3/log" target="_blank"><b class="btn btn-danger btn-sm btn-logs">
                 {{index $match.RedTeams 2}}
               </b></a>
+              {{end}}
             </td>
             <td class="bg-{{$match.ColorClass}} text-center">
               <a href="/match_logs/{{$match.Id}}/B1/log" target="_blank"><b class="btn btn-primary btn-sm btn-logs">
@@ -60,9 +62,11 @@ UI for listing matches and their logs.
               <a href="/match_logs/{{$match.Id}}/B2/log" target="_blank"><b class="btn btn-primary btn-sm btn-logs">
                 {{index $match.BlueTeams 1}}
               </b></a>
+              {{if not $.EventSettings.TwoVsTwoMode}}
               <a href="/match_logs/{{$match.Id}}/B3/log" target="_blank"><b class="btn btn-primary btn-sm btn-logs">
                 {{index $match.BlueTeams 2}}
               </b></a>
+              {{end}}
             </td>
           </tr>
           {{end}}

--- a/templates/match_review.html
+++ b/templates/match_review.html
@@ -46,10 +46,10 @@ UI for listing matches and their results.
             <td class="bg-{{$m.ColorClass}}">{{$m.ShortName}}</td>
             <td class="bg-{{$m.ColorClass}}">{{$m.Time}}</td>
             <td class="bg-{{$m.ColorClass}} text-center red-text">
-              {{index $m.RedTeams 0}}, {{index $m.RedTeams 1}}, {{index $m.RedTeams 2}}
+              {{index $m.RedTeams 0}}, {{index $m.RedTeams 1}}{{if not $.EventSettings.TwoVsTwoMode}}, {{index $m.RedTeams 2}}{{end}}
             </td>
             <td class="bg-{{$m.ColorClass}} text-center blue-text">
-              {{index $m.BlueTeams 0}}, {{index $m.BlueTeams 1}}, {{index $m.BlueTeams 2}}
+              {{index $m.BlueTeams 0}}, {{index $m.BlueTeams 1}}{{if not $.EventSettings.TwoVsTwoMode}}, {{index $m.BlueTeams 2}}{{end}}
             </td>
             <td class="bg-{{$m.ColorClass}} text-center red-text">{{if $m.IsComplete}}{{$m.RedScore}}{{end}}</td>
             <td class="bg-{{$m.ColorClass}} text-center blue-text">{{if $m.IsComplete}}{{$m.BlueScore}}{{end}}</td>

--- a/templates/queueing_display.html
+++ b/templates/queueing_display.html
@@ -13,7 +13,7 @@ Display that shows upcoming matches and timing information.
     <link rel="stylesheet" href="/static/css/cheesy-arena.css"/>
     <link rel="stylesheet" href="/static/css/queueing_display.css"/>
   </head>
-  <body>
+  <body{{if .EventSettings.TwoVsTwoMode}} class="two-vs-two"{{end}}>
     <div id="header" class="row justify-content-center">
       <div class="col-lg-5">Match Queue</div>
       <div class="col-lg-5 text-end">{{.EventSettings.Name}}</div>

--- a/templates/queueing_display_match_load.html
+++ b/templates/queueing_display_match_load.html
@@ -37,13 +37,13 @@
         <div class="col-lg-1 avatars text-end">
           <img class="avatar" src="/api/teams/{{$match.Red1}}/avatar"/><br/>
           <img class="avatar" src="/api/teams/{{$match.Red2}}/avatar"/><br/>
-          <img class="avatar" src="/api/teams/{{$match.Red3}}/avatar"/>
+          {{if not $.TwoVsTwoMode}}<img class="avatar" src="/api/teams/{{$match.Red3}}/avatar"/>{{end}}
         </div>
         <div class="col-lg-2 red-teams">
           {{if $match.Red1}}
           <div class="row">
             <div class="col-lg-8">
-              {{$match.Red1}}<br/>{{$match.Red2}}<br/>{{$match.Red3}}
+              {{$match.Red1}}<br/>{{$match.Red2}}{{if not $.TwoVsTwoMode}}<br/>{{$match.Red3}}{{end}}
               {{range $team := (index $.RedOffFieldTeams $i) }}
               <br/>{{$team}}
               {{end}}
@@ -70,7 +70,7 @@
               {{end}}
             </div>
             <div class="col-lg-8">
-              {{$match.Blue1}}<br/>{{$match.Blue2}}<br/>{{$match.Blue3}}
+              {{$match.Blue1}}<br/>{{$match.Blue2}}{{if not $.TwoVsTwoMode}}<br/>{{$match.Blue3}}{{end}}
               {{range $team := (index $.BlueOffFieldTeams $i) }}
               <br/>{{$team}}
               {{end}}
@@ -81,7 +81,7 @@
         <div class="col-lg-1 avatars">
           <img class="avatar" src="/api/teams/{{$match.Blue1}}/avatar"/><br/>
           <img class="avatar" src="/api/teams/{{$match.Blue2}}/avatar"/><br/>
-          <img class="avatar" src="/api/teams/{{$match.Blue3}}/avatar"/>
+          {{if not $.TwoVsTwoMode}}<img class="avatar" src="/api/teams/{{$match.Blue3}}/avatar"/>{{end}}
         </div>
       </div>
     </div>

--- a/templates/referee_panel.html
+++ b/templates/referee_panel.html
@@ -11,12 +11,12 @@ UI for entering and tracking fouls and red/yellow cards.
   <div id="cards" class="headRef-dependent">
     <h3>Red/Yellow Cards</h3>
     <div class="alliance-cards" id="redCards">
-      {{range $i := seq 3}}
+      {{range $i := seq .NumTeamsPerAlliance}}
       {{template "teamCard" dict "alliance" "red" "position" $i}}
       {{end}}
     </div>
     <div class="alliance-cards" id="blueCards">
-      {{range $i := seq 3}}
+      {{range $i := seq .NumTeamsPerAlliance}}
       {{template "teamCard" dict "alliance" "blue" "position" $i}}
       {{end}}
     </div>

--- a/templates/referee_panel_foul_list.html
+++ b/templates/referee_panel_foul_list.html
@@ -1,9 +1,9 @@
 {{define "referee_panel_foul_list"}}
 {{range $i, $foul := .RedFouls}}
-{{template "foul" dict "alliance" "red" "index" $i "foul" $foul "match" $.Match "rules" $.Rules}}
+{{template "foul" dict "alliance" "red" "index" $i "foul" $foul "match" $.Match "rules" $.Rules "twoVsTwoMode" $.TwoVsTwoMode}}
 {{end}}
 {{range $i, $foul := .BlueFouls}}
-{{template "foul" dict "alliance" "blue" "index" $i "foul" $foul "match" $.Match "rules" $.Rules}}
+{{template "foul" dict "alliance" "blue" "index" $i "foul" $foul "match" $.Match "rules" $.Rules "twoVsTwoMode" $.TwoVsTwoMode}}
 {{end}}
 {{end}}
 {{define "foul"}}
@@ -16,11 +16,15 @@
     {{if eq .alliance "red"}}
     {{template "teamButton" dict "alliance" .alliance "index" .index "foul" .foul "teamId" .match.Red1}}
     {{template "teamButton" dict "alliance" .alliance "index" .index "foul" .foul "teamId" .match.Red2}}
+    {{if not .twoVsTwoMode}}
     {{template "teamButton" dict "alliance" .alliance "index" .index "foul" .foul "teamId" .match.Red3}}
+    {{end}}
     {{else}}
     {{template "teamButton" dict "alliance" .alliance "index" .index "foul" .foul "teamId" .match.Blue1}}
     {{template "teamButton" dict "alliance" .alliance "index" .index "foul" .foul "teamId" .match.Blue2}}
+    {{if not .twoVsTwoMode}}
     {{template "teamButton" dict "alliance" .alliance "index" .index "foul" .foul "teamId" .match.Blue3}}
+    {{end}}
     {{end}}
   </div>
   <select class="rule-select" onchange="updateFoulRule('{{.alliance}}', {{.index}}, parseInt(this.value));">

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -57,6 +57,15 @@ UI for configuring event settings.
                 </div>
               </div>
               <div class="row mb-3">
+                <label class="col-lg-6 control-label" for="greenScreen">
+                  Green Screen
+                </label>
+                <div class="col-lg-1 checkbox">
+                  <input type="checkbox" id="greenScreen"
+                    name="greenScreen" {{if .GreenScreen}} checked{{end}}>
+                </div>
+              </div>
+              <div class="row mb-3">
                 <label class="col-lg-6 control-label" for="twoVsTwoMode">
                   2v2 Mode
                 </label>

--- a/web/alliance_selection.go
+++ b/web/alliance_selection.go
@@ -26,6 +26,7 @@ var allianceSelectionTicker *time.Ticker
 // Shows the alliance selection page.
 func (web *Web) allianceSelectionGetHandler(w http.ResponseWriter, r *http.Request) {
 	if !web.userIsAdmin(w, r) {
+		web.renderAllianceSelection(w, r, "You do not have the ability to set up alliances.")
 		return
 	}
 
@@ -117,6 +118,9 @@ func (web *Web) allianceSelectionStartHandler(w http.ResponseWriter, r *http.Req
 	// Create a blank alliance set matching the event configuration.
 	web.arena.AllianceSelectionAlliances = make([]model.Alliance, web.arena.EventSettings.NumPlayoffAlliances)
 	teamsPerAlliance := 3
+	if web.arena.EventSettings.TwoVsTwoMode {
+		teamsPerAlliance = 2
+	}
 	if web.arena.EventSettings.SelectionRound3Order != "" {
 		teamsPerAlliance = 4
 	}
@@ -208,7 +212,12 @@ func (web *Web) allianceSelectionFinalizeHandler(w http.ResponseWriter, r *http.
 		// the left, second pick on the right).
 		alliance.Lineup[0] = alliance.TeamIds[1]
 		alliance.Lineup[1] = alliance.TeamIds[0]
-		alliance.Lineup[2] = alliance.TeamIds[2]
+		if web.arena.EventSettings.TwoVsTwoMode {
+			// There is no third team in 2v2 alliances.
+			alliance.Lineup[2] = alliance.TeamIds[0]
+		} else {
+			alliance.Lineup[2] = alliance.TeamIds[2]
+		}
 
 		err := web.arena.Database.CreateAlliance(&alliance)
 		if err != nil {
@@ -390,17 +399,29 @@ func (web *Web) determineNextCell() (int, int) {
 		}
 	}
 
-	// Check the third column.
-	if web.arena.EventSettings.SelectionRound2Order == "F" {
-		for i, alliance := range web.arena.AllianceSelectionAlliances {
-			if alliance.TeamIds[2] == 0 {
-				return i, 2
+	// The third column (TeamIds[2]) exists whenever an alliance has more than 2 team slots -- i.e. in
+	// 3v3 mode (3 or 4 slots), or in 2v2 mode combined with a fourth-round selection (4 slots). Only a
+	// plain 2v2 alliance (2 slots) has no third column.
+	teamsPerAlliance := 3
+	if web.arena.EventSettings.TwoVsTwoMode {
+		teamsPerAlliance = 2
+	}
+	if web.arena.EventSettings.SelectionRound3Order != "" {
+		teamsPerAlliance = 4
+	}
+	if teamsPerAlliance > 2 {
+		// Check the third column.
+		if web.arena.EventSettings.SelectionRound2Order == "F" {
+			for i, alliance := range web.arena.AllianceSelectionAlliances {
+				if alliance.TeamIds[2] == 0 {
+					return i, 2
+				}
 			}
-		}
-	} else {
-		for i := len(web.arena.AllianceSelectionAlliances) - 1; i >= 0; i-- {
-			if web.arena.AllianceSelectionAlliances[i].TeamIds[2] == 0 {
-				return i, 2
+		} else {
+			for i := len(web.arena.AllianceSelectionAlliances) - 1; i >= 0; i-- {
+				if web.arena.AllianceSelectionAlliances[i].TeamIds[2] == 0 {
+					return i, 2
+				}
 			}
 		}
 	}

--- a/web/audience_display.go
+++ b/web/audience_display.go
@@ -14,11 +14,15 @@ import (
 
 // Renders the audience display to be chroma keyed over the video feed.
 func (web *Web) audienceDisplayHandler(w http.ResponseWriter, r *http.Request) {
+	backgroundColor := "#0f0"
+	if !web.arena.EventSettings.GreenScreen {
+		backgroundColor = "#333"
+	}
 	if !web.enforceDisplayConfiguration(
 		w,
 		r,
 		map[string]string{
-			"background": "#0f0", "reversed": "false",
+			"background": backgroundColor, "reversed": "false",
 			"overlayLocation": "bottom",
 		},
 	) {

--- a/web/audience_display_test.go
+++ b/web/audience_display_test.go
@@ -16,7 +16,7 @@ func TestAudienceDisplay(t *testing.T) {
 	recorder := web.getHttpResponse("/displays/audience")
 	assert.Equal(t, 302, recorder.Code)
 	assert.Contains(t, recorder.Header().Get("Location"), "displayId=100")
-	assert.Contains(t, recorder.Header().Get("Location"), "background=%230f0")
+	assert.Contains(t, recorder.Header().Get("Location"), "background=%23333")
 	assert.Contains(t, recorder.Header().Get("Location"), "reversed=false")
 	assert.Contains(t, recorder.Header().Get("Location"), "overlayLocation=bottom")
 

--- a/web/match_review.go
+++ b/web/match_review.go
@@ -92,13 +92,21 @@ func (web *Web) matchReviewEditGetHandler(w http.ResponseWriter, r *http.Request
 		handleWebErr(w, err)
 		return
 	}
+	numTeamsPerAlliance := 3
+	if web.arena.EventSettings.TwoVsTwoMode {
+		numTeamsPerAlliance = 2
+	}
 	data := struct {
 		*model.EventSettings
-		Match           *model.Match
-		MatchResultJson string
-		IsCurrentMatch  bool
-		Rules           map[int]*game.Rule
-	}{web.arena.EventSettings, match, string(matchResultJson), isCurrent, game.GetAllRules()}
+		Match               *model.Match
+		MatchResultJson     string
+		IsCurrentMatch      bool
+		Rules               map[int]*game.Rule
+		NumTeamsPerAlliance int
+	}{
+		web.arena.EventSettings, match, string(matchResultJson), isCurrent, game.GetAllRules(),
+		numTeamsPerAlliance,
+	}
 	err = template.ExecuteTemplate(w, "base", data)
 	if err != nil {
 		handleWebErr(w, err)

--- a/web/queueing_display.go
+++ b/web/queueing_display.go
@@ -94,10 +94,12 @@ func (web *Web) queueingDisplayMatchLoadHandler(w http.ResponseWriter, r *http.R
 		Matches           []model.Match
 		RedOffFieldTeams  [][]int
 		BlueOffFieldTeams [][]int
+		TwoVsTwoMode      bool
 	}{
 		upcomingMatches,
 		redOffFieldTeamsByMatch,
 		blueOffFieldTeamsByMatch,
+		web.arena.EventSettings.TwoVsTwoMode,
 	}
 	err = template.ExecuteTemplate(w, "queueing_display_match_load.html", data)
 	if err != nil {

--- a/web/referee_panel.go
+++ b/web/referee_panel.go
@@ -30,9 +30,15 @@ func (web *Web) refereePanelHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	numTeamsPerAlliance := 3
+	if web.arena.EventSettings.TwoVsTwoMode {
+		numTeamsPerAlliance = 2
+	}
+
 	data := struct {
 		*model.EventSettings
-	}{web.arena.EventSettings}
+		NumTeamsPerAlliance int
+	}{web.arena.EventSettings, numTeamsPerAlliance}
 	err = template.ExecuteTemplate(w, "base_no_navbar", data)
 	if err != nil {
 		handleWebErr(w, err)
@@ -48,16 +54,25 @@ func (web *Web) refereePanelFoulListHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	numTeamsPerAlliance := 3
+	if web.arena.EventSettings.TwoVsTwoMode {
+		numTeamsPerAlliance = 2
+	}
+
 	data := struct {
-		Match     *model.Match
-		RedFouls  []game.Foul
-		BlueFouls []game.Foul
-		Rules     map[int]*game.Rule
+		Match               *model.Match
+		RedFouls            []game.Foul
+		BlueFouls           []game.Foul
+		Rules               map[int]*game.Rule
+		NumTeamsPerAlliance int
+		TwoVsTwoMode        bool
 	}{
 		web.arena.CurrentMatch,
 		web.arena.RedRealtimeScore.CurrentScore.Fouls,
 		web.arena.BlueRealtimeScore.CurrentScore.Fouls,
 		game.GetAllRules(),
+		numTeamsPerAlliance,
+		web.arena.EventSettings.TwoVsTwoMode,
 	}
 	err = template.ExecuteTemplate(w, "referee_panel_foul_list", data)
 	if err != nil {

--- a/web/reports.go
+++ b/web/reports.go
@@ -448,7 +448,18 @@ func (web *Web) schedulePdfReportHandler(w http.ResponseWriter, r *http.Request)
 	}
 	matchesPerTeam := 0
 	if len(teams) > 0 {
-		matchesPerTeam = len(matches) * tournament.TeamsPerMatch / len(teams)
+		teamsPerMatch := tournament.TeamsPerMatch
+		if web.arena.EventSettings.TwoVsTwoMode {
+			teamsPerMatch = 4
+		}
+		matchesPerTeam = len(matches) * teamsPerMatch / len(teams)
+	}
+
+	// In 2v2 mode, "Blue 2" is the last column, so its row needs to end with a line break instead of a column
+	// separator.
+	blue2LineBreak := 0
+	if web.arena.EventSettings.TwoVsTwoMode {
+		blue2LineBreak = 1
 	}
 
 	// The widths of the table columns in mm, stored here so that they can be referenced for each row.
@@ -466,10 +477,14 @@ func (web *Web) schedulePdfReportHandler(w http.ResponseWriter, r *http.Request)
 	pdf.CellFormat(colWidths["Match"], rowHeight, "Match", "1", 0, "C", true, 0, "")
 	pdf.CellFormat(colWidths["Team"], rowHeight, "Red 1", "1", 0, "C", true, 0, "")
 	pdf.CellFormat(colWidths["Team"], rowHeight, "Red 2", "1", 0, "C", true, 0, "")
-	pdf.CellFormat(colWidths["Team"], rowHeight, "Red 3", "1", 0, "C", true, 0, "")
+	if !web.arena.EventSettings.TwoVsTwoMode {
+		pdf.CellFormat(colWidths["Team"], rowHeight, "Red 3", "1", 0, "C", true, 0, "")
+	}
 	pdf.CellFormat(colWidths["Team"], rowHeight, "Blue 1", "1", 0, "C", true, 0, "")
-	pdf.CellFormat(colWidths["Team"], rowHeight, "Blue 2", "1", 0, "C", true, 0, "")
-	pdf.CellFormat(colWidths["Team"], rowHeight, "Blue 3", "1", 1, "C", true, 0, "")
+	pdf.CellFormat(colWidths["Team"], rowHeight, "Blue 2", "1", blue2LineBreak, "C", true, 0, "")
+	if !web.arena.EventSettings.TwoVsTwoMode {
+		pdf.CellFormat(colWidths["Team"], rowHeight, "Blue 3", "1", 1, "C", true, 0, "")
+	}
 	pdf.SetFont("Arial", "", 10)
 	for _, match := range matches {
 		// Render break if there is one before this match.
@@ -486,8 +501,8 @@ func (web *Web) schedulePdfReportHandler(w http.ResponseWriter, r *http.Request)
 		borderStr := "1"
 		alignStr := "CM"
 		surrogate := false
-		if match.Red1IsSurrogate || match.Red2IsSurrogate || match.Red3IsSurrogate ||
-			match.Blue1IsSurrogate || match.Blue2IsSurrogate || match.Blue3IsSurrogate {
+		if match.Red1IsSurrogate || match.Red2IsSurrogate || match.Blue1IsSurrogate || match.Blue2IsSurrogate ||
+			(!web.arena.EventSettings.TwoVsTwoMode && (match.Red3IsSurrogate || match.Blue3IsSurrogate)) {
 			// If the match contains surrogates, the row needs to be taller to fit some text beneath team numbers.
 			height = 5.0
 			borderStr = "LTR"
@@ -518,10 +533,14 @@ func (web *Web) schedulePdfReportHandler(w http.ResponseWriter, r *http.Request)
 		pdf.CellFormat(colWidths["Match"], height, match.LongName, borderStr, 0, alignStr, false, 0, "")
 		pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Red1), borderStr, 0, alignStr, false, 0, "")
 		pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Red2), borderStr, 0, alignStr, false, 0, "")
-		pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Red3), borderStr, 0, alignStr, false, 0, "")
+		if !web.arena.EventSettings.TwoVsTwoMode {
+			pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Red3), borderStr, 0, alignStr, false, 0, "")
+		}
 		pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Blue1), borderStr, 0, alignStr, false, 0, "")
-		pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Blue2), borderStr, 0, alignStr, false, 0, "")
-		pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Blue3), borderStr, 1, alignStr, false, 0, "")
+		pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Blue2), borderStr, blue2LineBreak, alignStr, false, 0, "")
+		if !web.arena.EventSettings.TwoVsTwoMode {
+			pdf.CellFormat(colWidths["Team"], height, formatTeam(match.Blue3), borderStr, 1, alignStr, false, 0, "")
+		}
 		if surrogate {
 			// Render the text that indicates which teams are surrogates.
 			height := 4.0
@@ -534,18 +553,22 @@ func (web *Web) schedulePdfReportHandler(w http.ResponseWriter, r *http.Request)
 			pdf.CellFormat(
 				colWidths["Team"], height, surrogateText(match.Red2IsSurrogate), "LBR", 0, "CT", false, 0, "",
 			)
-			pdf.CellFormat(
-				colWidths["Team"], height, surrogateText(match.Red3IsSurrogate), "LBR", 0, "CT", false, 0, "",
-			)
+			if !web.arena.EventSettings.TwoVsTwoMode {
+				pdf.CellFormat(
+					colWidths["Team"], height, surrogateText(match.Red3IsSurrogate), "LBR", 0, "CT", false, 0, "",
+				)
+			}
 			pdf.CellFormat(
 				colWidths["Team"], height, surrogateText(match.Blue1IsSurrogate), "LBR", 0, "CT", false, 0, "",
 			)
 			pdf.CellFormat(
-				colWidths["Team"], height, surrogateText(match.Blue2IsSurrogate), "LBR", 0, "CT", false, 0, "",
+				colWidths["Team"], height, surrogateText(match.Blue2IsSurrogate), "LBR", blue2LineBreak, "CT", false, 0, "",
 			)
-			pdf.CellFormat(
-				colWidths["Team"], height, surrogateText(match.Blue3IsSurrogate), "LBR", 1, "CT", false, 0, "",
-			)
+			if !web.arena.EventSettings.TwoVsTwoMode {
+				pdf.CellFormat(
+					colWidths["Team"], height, surrogateText(match.Blue3IsSurrogate), "LBR", 1, "CT", false, 0, "",
+				)
+			}
 			pdf.SetFont("Arial", "", 10)
 		}
 	}

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -74,6 +74,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.SelectionRound2Order = r.PostFormValue("selectionRound2Order")
 	eventSettings.SelectionRound3Order = r.PostFormValue("selectionRound3Order")
 	eventSettings.SelectionShowUnpickedTeams = r.PostFormValue("selectionShowUnpickedTeams") == "on"
+	eventSettings.GreenScreen = r.PostFormValue("greenScreen") == "on"
 	eventSettings.TwoVsTwoMode = r.PostFormValue("twoVsTwoMode") == "on"
 	eventSettings.NetworkSecurityEnabled = r.PostFormValue("networkSecurityEnabled") == "on"
 	eventSettings.ApAddress = r.PostFormValue("apAddress")


### PR DESCRIPTION
Preparing for M-Ayhem 2026!  As part of that, starting off by backporting changes made in mayhem-fms-2025 that were really generic changes but didn't make it into generic at the time due to schedule crunch.

- Backport 2v2 mode visual and logic completeness across alliance selection, referee panel, match review, displays, and reports.
- Fix alliance-selection blank-page bug for non-admin users.
- Add GreenScreen option to EventSettings and update audience display default background.
- Polish audience display final-breakdown CSS layouts.
- Rename ScoreSummary ranking point fields to Auton, Scoring, and Endgame RP.

Schedule generation code needs some work and will be done in a separate PR.